### PR TITLE
Update the GET roommates API to search by profile query params

### DIFF
--- a/backend/docs/api.md
+++ b/backend/docs/api.md
@@ -64,9 +64,19 @@ GET /roommate/personalities
 GET /roommate
 ```
 
-Include the authorization header. Optionally include a `username` query parameter to retrieve a single roommate.
+Include the authorization header.
 
-Example Request:
+Options:
+
+- With no query parameters set, all roommate profiles will be retrieved.
+
+- When the optional `username` query parameter is included, a single roommate profile will be returned if the username exists.
+
+- When optional `firstName`, `lastName`, `email`, and/or `area` query parameters are included, an array of roommate profiles that match the search criteria will be returned.
+
+Note that the `username` query parameter takes precedence over these profile query parameters. In other words, if `username` is present in the query parameters, the other query parameters are ignored. When searching by roommate profile filters, you can include any number of the query parameters. You do not need to include all the profile query parameters.
+
+Example Request (find all roommates):
 
 ```
 curl --location --request GET 'http://localhost:3000/roommate/' \
@@ -76,23 +86,31 @@ curl --location --request GET 'http://localhost:3000/roommate/' \
 Example Response:
 
 ```
-{
-    "data": [
-        {
-            "firstName": "AndrewNewName",
-            "lastName": "Changy",
-            "email": "andrewwww@gmail.com",
-            "area": "Los Angeles",
-            "bio": "UCLA grad",
-            "hobbies": [],
-            "personality": [],
-            "additionalInfo": "Looking for 2 roommates"
-        }
-    ]
-}
+[
+    {
+        "firstName": "Andrew",
+        "lastName": "Chang",
+        "email": "andrewwww@gmail.com",
+        "area": "Los Angeles",
+        "bio": "UCLA graduate",
+        "hobbies": [],
+        "personality": [],
+        "additionalInfo": "Looking for 2 roommates"
+    },
+    {
+        "firstName": "John",
+        "lastName": "Doe",
+        "email": "john@gmail.com",
+        "area": "Los Angeles",
+        "bio": "UCLA grad",
+        "hobbies": [],
+        "personality": [],
+        "additionalInfo": "Looking for 3 roommates"
+    }
+]
 ```
 
-Example Request (querying for 1 roommate):
+Example Request (querying for 1 roommate by username):
 
 ```
 curl --location --request GET 'http://localhost:3000/roommate/?username=Andrew1' \
@@ -112,6 +130,40 @@ Example Response:
     "personality": [],
     "additionalInfo": "Looking for 2 roommates"
 }
+```
+
+Example Request (querying for roommate profiles using filters):
+
+```
+curl --location --request GET 'http://localhost:3000/roommate/?firstName=Andrew&lastName=Chang' \
+--header 'authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6IkFuZHJldyIsInNhbHQiOiJiY1NoRFZqSXI2dHpsYVBGemdhRHlRPT0iLCJpYXQiOjE2NDQ2NzIxNTYsImV4cCI6MTY0NDY3Mzk1Nn0.0-CzWP1TEB5IsJQUgEKxJBHxv8E3W3OeTKVs5iR2wSU'
+```
+
+Example Response:
+
+```
+[
+    {
+        "firstName": "Andrew",
+        "lastName": "Chang",
+        "email": "andrewwww@gmail.com",
+        "area": "Los Angeles",
+        "bio": "UCLA graduate",
+        "hobbies": [],
+        "personality": [],
+        "additionalInfo": "Looking for 2 roommates"
+    },
+    {
+        "firstName": "Andrew",
+        "lastName": "Chang",
+        "email": "andrew@gmail.com",
+        "area": "Los Angeles",
+        "bio": "UCLA grad",
+        "hobbies": [],
+        "personality": [],
+        "additionalInfo": "Looking for 2 roommates"
+    }
+]
 ```
 
 Notice that this endpoint is returning roommate _profiles_. (Usernames and passwords are not included.)

--- a/backend/src/repository/RoommateRepository.ts
+++ b/backend/src/repository/RoommateRepository.ts
@@ -2,11 +2,13 @@ import { Roommate } from "../roommate/roommate";
 import { RoommateProfile } from "../roommate/roommateProfile";
 import { RoommateModel } from "./Schemas";
 import { injectable } from "inversify";
+import _ from "lodash";
 import "reflect-metadata";
 
 export interface RoommateRepository {
   create(roommate: Roommate): Promise<boolean>;
   findOne(username: string): Promise<Roommate | null>;
+  findWhere(profile: Partial<RoommateProfile>): Promise<Roommate[]>;
   findOverlap(
     profileFields: Partial<RoommateProfile>,
     keysToIgnore?: string[]
@@ -43,6 +45,17 @@ export class RoommateRepositoryImplMongo implements RoommateRepository {
   async findOne(username: string): Promise<Roommate | null> {
     const roommate = await RoommateModel.findOne({ username: username });
     return roommate ? roommate.toObject() : null;
+  }
+
+  /**
+   * Finds a roommate whose profile matches profile fields
+   * @param profile a partial RoommateProfile
+   * @returns an array of roommates who match search criteria
+   */
+  async findWhere(profile: Partial<RoommateProfile>): Promise<Roommate[]> {
+    const filter = _.mapKeys(profile, (value, key) => "profile." + key);
+    const roommateDocs = await RoommateModel.find(filter);
+    return roommateDocs.map((roommateDoc) => roommateDoc.toObject());
   }
 
   /**

--- a/backend/src/services/RoommateService.ts
+++ b/backend/src/services/RoommateService.ts
@@ -14,6 +14,12 @@ export class RoommateService {
     return await this.roommateRepository.getAll();
   }
 
+  public async findRoommatesWhere(
+    profile: Partial<RoommateProfile>
+  ): Promise<Roommate[]> {
+    return await this.roommateRepository.findWhere(profile);
+  }
+
   public async createRoommate(roommate: Roommate): Promise<boolean> {
     return await this.roommateRepository.create(roommate);
   }

--- a/backend/tests/e2e-tests/RoommatesApi.test.ts
+++ b/backend/tests/e2e-tests/RoommatesApi.test.ts
@@ -118,11 +118,34 @@ describe("Roommates API", function () {
       .set("Accept", "application/json")
       .set("Authorization", authorizationHeader);
     expect(getRoommatesResponse.status).toEqual(200);
-    expect(getRoommatesResponse.body.data).toEqual(
+    expect(getRoommatesResponse.body).toEqual(
       expect.arrayContaining([
         updatedTestRoommate.profile,
         testRoommate2.profile,
       ])
+    );
+
+    const getRoommateByUsernameResponse = await request(app)
+      .get("/roommate/")
+      .query({ username: updatedTestRoommate.username })
+      .set("Accept", "application/json")
+      .set("Authorization", authorizationHeader);
+    expect(getRoommateByUsernameResponse.status).toEqual(200);
+    expect(getRoommateByUsernameResponse.body).toEqual(
+      updatedTestRoommate.profile
+    );
+
+    const getRoommatesByFilterResponse = await request(app)
+      .get("/roommate/")
+      .query({
+        firstName: testRoommate2.profile.firstName,
+        email: testRoommate2.profile.email,
+      })
+      .set("Accept", "application/json")
+      .set("Authorization", authorizationHeader);
+    expect(getRoommatesByFilterResponse.status).toEqual(200);
+    expect(getRoommatesByFilterResponse.body).toEqual(
+      expect.arrayContaining([testRoommate2.profile])
     );
 
     const getRecommendationsResponse = await request(app)

--- a/backend/tests/unit-tests/AuthorizationService.test.ts
+++ b/backend/tests/unit-tests/AuthorizationService.test.ts
@@ -41,6 +41,11 @@ class RoommateRepositoryMock implements RoommateRepository {
       return null;
     }
   }
+
+  async findWhere(profile: Partial<RoommateProfile>): Promise<Roommate[]> {
+    throw new Error("Function should not be called for this unit test");
+  }
+
   async getAll(): Promise<Roommate[]> {
     return [testRoommate];
   }

--- a/backend/tests/unit-tests/RecommendationService.test.ts
+++ b/backend/tests/unit-tests/RecommendationService.test.ts
@@ -145,6 +145,11 @@ class RoommateRepositoryMock implements RoommateRepository {
   async findOne(username: string): Promise<Roommate | null> {
     throw new Error("Function should not be called for this unit test");
   }
+
+  async findWhere(profile: Partial<RoommateProfile>): Promise<Roommate[]> {
+    throw new Error("Function should not be called for this unit test");
+  }
+
   async getAll(): Promise<Roommate[]> {
     throw new Error("Function should not be called for this unit test");
   }

--- a/backend/tests/unit-tests/RoommateRepository.test.ts
+++ b/backend/tests/unit-tests/RoommateRepository.test.ts
@@ -59,7 +59,7 @@ const roommate3: Roommate = {
   username: "Jessica",
   password: "JessicaPassword",
   profile: {
-    firstName: "Tom",
+    firstName: "Jessica",
     lastName: "Richard",
     email: "tom@gmail.com",
     area: "Los Angeles" as Area,
@@ -99,6 +99,16 @@ describe("Roommate Repository", () => {
     expect(await roommateRepository.findOne(roommate1.username)).toEqual(
       roommate1
     );
+
+    expect(
+      await roommateRepository.findWhere({ area: roommate2.profile.area })
+    ).toEqual(expect.arrayContaining([roommate2, roommate3]));
+    expect(
+      await roommateRepository.findWhere({
+        lastName: roommate1.profile.lastName,
+      })
+    ).toEqual(expect.arrayContaining([roommate1]));
+
     expect(await roommateRepository.getAll()).toEqual(
       expect.arrayContaining(roommates)
     );


### PR DESCRIPTION
With this PR, you can now search for roommate profiles using filters in the `GET /roommates` endpoint.

You can filter by `firstName`, `lastName`, `email`, and / or `area` when they are included as query parameters.

The endpoints for retrieving multiple roommates have also been modified to return an array of profiles, rather than an object containing a `data` property (which contained the array).

The API docs have also been updated.