### PR TITLE
Fix bug in authorization middleware

### DIFF
--- a/backend/src/middleware/AuthorizationMiddleware.ts
+++ b/backend/src/middleware/AuthorizationMiddleware.ts
@@ -12,7 +12,10 @@ export class AuthorizationMiddleware {
   public verifyToken = (req: Request, res: Response, next: NextFunction) => {
     try {
       const authorization: string = req.headers.authorization;
-      const username = req.params["username"];
+      const username =
+        req.method === "POST" || req.method === "PUT" || req.method === "DELETE"
+          ? req.params["username"]
+          : undefined;
       const validToken = this.authorizationService.validToken(
         authorization,
         username

--- a/backend/src/middleware/AuthorizationMiddleware.ts
+++ b/backend/src/middleware/AuthorizationMiddleware.ts
@@ -12,10 +12,9 @@ export class AuthorizationMiddleware {
   public verifyToken = (req: Request, res: Response, next: NextFunction) => {
     try {
       const authorization: string = req.headers.authorization;
-      const username =
-        req.method === "POST" || req.method === "PUT" || req.method === "DELETE"
-          ? req.params["username"]
-          : undefined;
+      const username = this.requireUsernameParamToMatchToken(req)
+        ? req.params["username"]
+        : undefined;
       const validToken = this.authorizationService.validToken(
         authorization,
         username
@@ -47,4 +46,14 @@ export class AuthorizationMiddleware {
       res.status(500).json({ message: "Failed to encrypt password." });
     }
   };
+
+  private requireUsernameParamToMatchToken(req: Request): boolean {
+    return (
+      req.method === "POST" ||
+      req.method === "PUT" ||
+      req.method === "DELETE" ||
+      req.url.startsWith("/roommate/list") ||
+      req.url.startsWith("/roommate/recommendations/")
+    );
+  }
 }

--- a/backend/src/middleware/AuthorizationMiddleware.ts
+++ b/backend/src/middleware/AuthorizationMiddleware.ts
@@ -53,7 +53,7 @@ export class AuthorizationMiddleware {
       req.method === "PUT" ||
       req.method === "DELETE" ||
       req.url.startsWith("/roommate/list") ||
-      req.url.startsWith("/roommate/recommendations/")
+      req.url.startsWith("/roommate/recommendations")
     );
   }
 }

--- a/backend/tests/e2e-tests/RoommatesApi.test.ts
+++ b/backend/tests/e2e-tests/RoommatesApi.test.ts
@@ -218,7 +218,7 @@ describe("Roommates API", function () {
       .get("/roommate/list/differentUsername")
       .set("Accept", "application/json")
       .set("Authorization", authorizationHeader);
-    expect(failedGetRoommateList.status).toEqual(401);
+    expect(failedGetRoommateList.status).toEqual(404);
 
     const failedAddToRoommateList2 = await request(app)
       .post("/roommate/list/username")

--- a/backend/tests/e2e-tests/RoommatesApi.test.ts
+++ b/backend/tests/e2e-tests/RoommatesApi.test.ts
@@ -218,7 +218,7 @@ describe("Roommates API", function () {
       .get("/roommate/list/differentUsername")
       .set("Accept", "application/json")
       .set("Authorization", authorizationHeader);
-    expect(failedGetRoommateList.status).toEqual(404);
+    expect(failedGetRoommateList.status).toEqual(401);
 
     const failedAddToRoommateList2 = await request(app)
       .post("/roommate/list/username")


### PR DESCRIPTION
This bug was preventing a user `A` from making a request to see user `B`'s profile (in particular). This endpoint was affected: `GET  /roommate/:username`. Note that `GET /roommate` works because there is no check for the username for the token validation function.

I changed the authorization middleware to allow users to access any of other user's info (including recommendations and lists). A user is just prevented from POST, PUT, and DELETE endpoints which would modify other user's profile information.