### PR TITLE
Fix bug with type returned by get roommates with filter

### DIFF
--- a/backend/src/controllers/RoommateController.ts
+++ b/backend/src/controllers/RoommateController.ts
@@ -38,7 +38,9 @@ export class RoommateController implements RegistrableController {
         const filteredPartialProfile = _.omitBy(partialProfile, _.isUndefined);
         const roommateProfiles = (
           await this.roommateService.findRoommatesWhere(filteredPartialProfile)
-        ).map((roommate) => roommate.profile);
+        ).map((roommate) => {
+          return { username: roommate.username, profile: roommate.profile };
+        });
         res.status(200).json(roommateProfiles);
       } else {
         const roommateProfiles = (

--- a/backend/tests/e2e-tests/RoommatesApi.test.ts
+++ b/backend/tests/e2e-tests/RoommatesApi.test.ts
@@ -147,7 +147,9 @@ describe("Roommates API", function () {
       .set("Authorization", authorizationHeader);
     expect(getRoommatesByFilterResponse.status).toEqual(200);
     expect(getRoommatesByFilterResponse.body).toEqual(
-      expect.arrayContaining([testRoommate2.profile])
+      expect.arrayContaining([
+        { username: testRoommate2.username, profile: testRoommate2.profile },
+      ])
     );
 
     const getRecommendationsResponse = await request(app)


### PR DESCRIPTION
The response for getting roommates with filter was not returning the same type as the regular GET roommates. They should both include the username and profile.