### PR TITLE
Update main README to include info on building and deploying app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Building and Deploying Zoomie Roomies
-The builds and deployments are handled automatically by TravisCI. Builds are triggered whenever a pull request is made or a commit is made to the main branch. Deployments are made to Heroku whenever commits are made to the main branch. The frontend app is deployed at https://use-zoomie-roomies.herokuapp.com/ and the backend is deployed at https://zoomie-roomies.herokuapp.com/.
+The builds and deployments are handled automatically by TravisCI. Builds are triggered whenever a pull request is made or a commit is made to the main branch. Deployments are triggered and made to Heroku whenever commits are made to the main branch. The frontend app is deployed at https://use-zoomie-roomies.herokuapp.com/ and the backend is deployed at https://zoomie-roomies.herokuapp.com/.
 
 For instructions on how to build the frontend and backend apps locally, refer to the README's in the frontend/react and backend folders.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
+# Building and Deploying Zoomie Roomies
+The builds and deployments are handled automatically by TravisCI. Builds are triggered whenever a pull request is made or a commit is made to the main branch. Deployments are made to Heroku whenever commits are made to the main branch. The frontend app is deployed at https://use-zoomie-roomies.herokuapp.com/ and the backend is deployed at https://zoomie-roomies.herokuapp.com/.
+
+For instructions on how to build the frontend and backend apps locally, refer to the README's in the frontend/react and backend folders.
+
 # Repository Template
 
-[![Build Status](https://travis-ci.org/cs130-w21/template.svg?branch=master)](https://travis-ci.org/cs130-w21/template)
+[![Build Status](https://app.travis-ci.com/cs130-w22/Group-B1.svg?branch=main)](https://app.travis-ci.com/github/cs130-w22/Group-B1)
 [![Release](https://img.shields.io/github/v/release/cs130-w21/template?label=release)](https://github.com/cs130-w21/template/releases/latest)
 
 This repo serves as a template for repositories in this organization. The following information describes how the native features/workflows of Github can be customized to work in a scrum development process.


### PR DESCRIPTION
This is one of the requirements of Part C: 
"Update your repository’s main README.md to have clear instructions on how to trigger your build"
"Make sure there are clear instructions on how to build and deploy your application on your repo’s README.md file,"


I also changed the button to include whether our build is currently passing. We don't have any official releases so I left that status image the same.